### PR TITLE
Source bundles should include from project source directory.

### DIFF
--- a/releng/maven-plugins/ebr-maven-plugin/src/main/java/org/eclipse/ebr/maven/BundleMojo.java
+++ b/releng/maven-plugins/ebr-maven-plugin/src/main/java/org/eclipse/ebr/maven/BundleMojo.java
@@ -360,7 +360,8 @@ public class BundleMojo extends ManifestPlugin {
 							configuration(
 									element("outputDirectory", "${project.build.directory}/dependency-src"),
 									element("resources",
-											element("resource", element("directory", "${project.basedir}/src/main/resources"))
+											element("resource", element("directory", "${project.basedir}/src/main/resources")),
+											element("resource", element("directory", "${project.basedir}/src/main/java"))
 											)
 									),
 									executionEnvironment(


### PR DESCRIPTION
If content is added to the project source directory (eg. src/main/java),
to be re-compiled, it should be picked up and added to the generated
source bundle. This setting is configurable using the
includeProjectResourceDir property

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

This should resolve the issue in https://git.eclipse.org/r/86970 . Specifically that the (latest) source file that gets recompiled does not end up in the source artifact.  