### PR TITLE
Add 'Public Domain' as a recognized 'license'.

### DIFF
--- a/releng/maven-plugins/ebr-maven-plugin/src/main/java/org/eclipse/ebr/maven/eclipseip/KnownLicenses.java
+++ b/releng/maven-plugins/ebr-maven-plugin/src/main/java/org/eclipse/ebr/maven/eclipseip/KnownLicenses.java
@@ -46,6 +46,7 @@ public class KnownLicenses {
 
 		addLicense("Mozilla Public License 1.0 (MPL)", "https://www.mozilla.org/MPL/1.0/");
 		addLicense("Mozilla Public License 1.1 (MPL)", "https://www.mozilla.org/MPL/1.1/");
+		addLicense("Public Domain", "https://creativecommons.org/publicdomain/zero/1.0/");
 	}
 
 	private KnownLicense addLicense(final String name, final String... knownUrls) {


### PR DESCRIPTION
This is prompted by the proposed addition of XZ for Java 1.5 into orbit-recipes, which is under Public Domain.

Does the "License" URL make sense ? I mean the format would require one to be specified.