### PR TITLE
Update to maven-bundle-plugin 2.5.4.

### DIFF
--- a/releng/maven-plugins/ebr-maven-plugin/pom.xml
+++ b/releng/maven-plugins/ebr-maven-plugin/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>maven-bundle-plugin</artifactId>
-      <version>2.5.3</version>
+      <version>2.5.4</version>
       <type>maven-plugin</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
maven-bundle-plugin 2.5.4 updated from biz.aQute.bndlib 2.3.0 to 2.4.1
which fixed an ArrayIndexOutOfBoundsException.

From https://git.eclipse.org/r/89028 (com.ibm.icu 58.2), building this results in https://hudson.eclipse.org/orbit/job/gerrit-orbit-recipes/266/consoleText

    [ERROR] Manifest org.eclipse.orbit.bundles:com.ibm.icu:eclipse-bundle-recipe:58.2.0-SNAPSHOT : Exception: 34983
    [ERROR] Manifest org.eclipse.orbit.bundles:com.ibm.icu:eclipse-bundle-recipe:58.2.0-SNAPSHOT : Invalid class file com/ibm/icu/text/SimpleDateFormat.class (java.lang.ArrayIndexOutOfBoundsException: 34983)

The issue is documented on https://issues.apache.org/jira/browse/FELIX-4556 and shows maven-bundle-plugin 2.5.4 as having a fix. In fact, maven-bundle-plugin updated to bndlib 2.4.1, which contained a fix for https://github.com/bndtools/bnd/issues/685 .