### PR TITLE
Allow shipping bundles with dependencies are jars within bundle

### DIFF
--- a/releng/maven-plugins/ebr-maven-plugin-its/src/test/java/org/eclipse/ebr/maven/tests/integration/RecipeAsserts.java
+++ b/releng/maven-plugins/ebr-maven-plugin-its/src/test/java/org/eclipse/ebr/maven/tests/integration/RecipeAsserts.java
@@ -1,0 +1,51 @@
+package org.eclipse.ebr.maven.tests.integration;
+
+import static io.takari.maven.testing.TestResources.assertFilesPresent;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+public class RecipeAsserts {
+
+	public static void assertFilesPresentInJar(final File baseDir, final String jarFile, final String... entries) throws IOException {
+		assertNotNull(entries);
+		assertNotNull(baseDir);
+		assertNotNull(jarFile);
+		assertFilesPresent(baseDir, jarFile);
+		try (JarFile recipeJar = new JarFile(baseDir.toPath().resolve(jarFile).toFile())) {
+			for (final String entry : entries) {
+				assertNotNull(format("'%s' expected in recipe bundle jar '%s'", entry, jarFile), recipeJar.getEntry(entry));
+			}
+		}
+	}
+
+	public static void assertManifestHeaderValue(final File baseDir, final String manifestFile, final String manifestHeader, final String expectedValue) throws IOException {
+		assertNotNull(manifestFile);
+		assertNotNull(baseDir);
+		assertNotNull(manifestHeader);
+		assertFilesPresent(baseDir, manifestFile);
+		try (InputStream is = new BufferedInputStream(Files.newInputStream(baseDir.toPath().resolve(manifestFile)))) {
+			final Manifest manifest = new Manifest(is);
+			final String actualValue = manifest.getMainAttributes().getValue(manifestHeader);
+			if (expectedValue == null) {
+				assertNull(format("No value expected for manifest header '%s'. Got: '%s'", manifestHeader, actualValue), actualValue);
+			} else {
+				assertEquals(format("Manifest header '%s' mismatch!", manifestHeader), expectedValue, actualValue);
+			}
+		}
+	}
+
+	private RecipeAsserts() {
+		// only static
+	}
+
+}

--- a/releng/maven-plugins/ebr-maven-plugin-its/src/test/java/org/eclipse/ebr/maven/tests/integration/RecipeWihtoutUnpackTest.java
+++ b/releng/maven-plugins/ebr-maven-plugin-its/src/test/java/org/eclipse/ebr/maven/tests/integration/RecipeWihtoutUnpackTest.java
@@ -1,5 +1,6 @@
 package org.eclipse.ebr.maven.tests.integration;
 
+import static io.takari.maven.testing.TestResources.assertFilesPresent;
 import static org.eclipse.ebr.maven.tests.integration.RecipeAsserts.assertFilesPresentInJar;
 import static org.eclipse.ebr.maven.tests.integration.RecipeAsserts.assertManifestHeaderValue;
 import static org.junit.Assert.assertTrue;
@@ -20,14 +21,14 @@ import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
 
 @RunWith(MavenJUnitTestRunner.class)
 @MavenVersions({ "3.3.9" })
-public class SimpleIntegrationTest {
+public class RecipeWihtoutUnpackTest {
 
 	@Rule
 	public final TestResources resources = new TestResources();
 
 	public final MavenRuntime verifier;
 
-	public SimpleIntegrationTest(final MavenRuntimeBuilder builder) throws Exception {
+	public RecipeWihtoutUnpackTest(final MavenRuntimeBuilder builder) throws Exception {
 		verifier = builder.withCliOptions("-X").build();
 	}
 
@@ -39,17 +40,20 @@ public class SimpleIntegrationTest {
 
 	@Test
 	public void test() throws Exception {
-		final File baseDir = getProjectDir("simple");
+		final File baseDir = getProjectDir("recipe-without-unpack");
 
 		final MavenExecutionResult result = verifier.forProject(baseDir).execute("package");
 
 		result.assertErrorFreeLog();
 
+		assertFilesPresent(baseDir, "target/classes/lib/ant-1.10.1.jar");
+		assertFilesPresent(baseDir, "target/classes/lib/ant-launcher-1.10.1.jar");
+
 		// check Bundle-ClassPath
-		assertManifestHeaderValue(baseDir, "target/MANIFEST.MF", "Bundle-ClassPath", null);
+		assertManifestHeaderValue(baseDir, "target/MANIFEST.MF", "Bundle-ClassPath", ".,lib/ant-1.10.1.jar,lib/ant-launcher-1.10.1.jar");
 
 		// check jar
-		assertFilesPresentInJar(baseDir, "target/simple-it-1.0.0-SNAPSHOT.jar", "org/junit/Test.class");
+		assertFilesPresentInJar(baseDir, "target/recipe-without-unpack-it-1.0.0-SNAPSHOT.jar", "lib/ant-1.10.1.jar", "lib/ant-launcher-1.10.1.jar");
 	}
 
 }

--- a/releng/maven-plugins/ebr-maven-plugin-its/src/test/projects/it-tests/recipe-without-unpack/pom.xml
+++ b/releng/maven-plugins/ebr-maven-plugin-its/src/test/projects/it-tests/recipe-without-unpack/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.eclipse.ebr.it</groupId>
+  <artifactId>recipe-without-unpack-it</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>eclipse-bundle-recipe</packaging>
+
+  <description>An IT verifying a recipe that does not unpack its dependencies.</description>
+
+  <properties>
+    <tycho-version>0.27.0-SNAPSHOT</tycho-version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>tycho-snapshots</id>
+      <url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.ant</groupId>
+      <artifactId>ant-launcher</artifactId>
+      <version>1.10.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.ant</groupId>
+      <artifactId>ant</artifactId>
+      <version>1.10.1</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.ebr</groupId>
+        <artifactId>ebr-maven-plugin</artifactId>
+        <version>${it-plugin.version}</version>
+        <extensions>true</extensions>
+        <configuration>
+          <unpackDependencies>false</unpackDependencies>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-maven-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-maven-plugin</artifactId>
+          <version>${tycho-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-packaging-plugin</artifactId>
+          <version>${tycho-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-p2-plugin</artifactId>
+          <version>${tycho-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-p2-repository-plugin</artifactId>
+          <version>${tycho-version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>


### PR DESCRIPTION
This allows to build bundles that will not unpack their dependencies but
place the jars inside a lib folder instead. Those jars will then form
the Bundle-ClassPath prefixed by '.'.

Note, sources will still be unpacked for simplicity.