### PR TITLE
Add ‘Custom License based on APL 1.1’ as a recognized license.

### DIFF
--- a/releng/maven-plugins/ebr-maven-plugin/src/main/java/org/eclipse/ebr/maven/eclipseip/KnownLicenses.java
+++ b/releng/maven-plugins/ebr-maven-plugin/src/main/java/org/eclipse/ebr/maven/eclipseip/KnownLicenses.java
@@ -33,6 +33,7 @@ public class KnownLicenses {
 
 	private KnownLicenses() {
 		addLicense("Apache Software License 1.1", "http://www.apache.org/licenses/LICENSE-1.1").setAlternateNames("Apache License, Version 1.0");
+		addLicense("Custom license based on Apache Software License 1.1");
 		addLicense("Apache License, 2.0", "http://www.apache.org/licenses/LICENSE-2.0.txt", "http://www.apache.org/licenses/LICENSE-2.0", "http://www.apache.org/licenses/LICENSE-2.0.html", "http://opensource.org/licenses/Apache-2.0");
 
 		addLicense("New BSD license", "http://opensource.org/licenses/BSD-3-Clause").setAlternateNames("The BSD 3-Clause License", "BSD New", "New BSD");


### PR DESCRIPTION
Such a license is used, e.g., by DOM4J. See [this message to `orbit-dev`](https://dev.eclipse.org/mhonarc/lists/orbit-dev/msg04845.html) for details.

FYI, due to the fuzzy license matching (Jaro-Winkler distance), “Custom license based on Apache Software License 1.1” also matches “Custom license based on Apache 1.1”, which is the term used by the Eclipse IP team in [7762](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=7762), but which is slightly less precise (Apache **Software License** vs. just Apache).