### PR TITLE
Add "SUN Industry Standards Source License 1.2" as a recognized license

### DIFF
--- a/releng/maven-plugins/ebr-maven-plugin/src/main/java/org/eclipse/ebr/maven/eclipseip/KnownLicenses.java
+++ b/releng/maven-plugins/ebr-maven-plugin/src/main/java/org/eclipse/ebr/maven/eclipseip/KnownLicenses.java
@@ -48,6 +48,7 @@ public class KnownLicenses {
 		addLicense("Mozilla Public License 1.0 (MPL)", "https://www.mozilla.org/MPL/1.0/");
 		addLicense("Mozilla Public License 1.1 (MPL)", "https://www.mozilla.org/MPL/1.1/");
 		addLicense("Public Domain", "https://creativecommons.org/publicdomain/zero/1.0/");
+		addLicense("SUN Industry Standards Source License 1.2", "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html").setAlternateNames("SISSL");
 	}
 
 	private KnownLicense addLicense(final String name, final String... knownUrls) {

--- a/releng/maven-plugins/ebr-maven-plugin/src/main/java/org/eclipse/ebr/maven/eclipseip/KnownLicenses.java
+++ b/releng/maven-plugins/ebr-maven-plugin/src/main/java/org/eclipse/ebr/maven/eclipseip/KnownLicenses.java
@@ -48,7 +48,7 @@ public class KnownLicenses {
 		addLicense("Mozilla Public License 1.0 (MPL)", "https://www.mozilla.org/MPL/1.0/");
 		addLicense("Mozilla Public License 1.1 (MPL)", "https://www.mozilla.org/MPL/1.1/");
 		addLicense("Public Domain", "https://creativecommons.org/publicdomain/zero/1.0/");
-		addLicense("SUN Industry Standards Source License 1.2", "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html").setAlternateNames("SISSL");
+		addLicense("SUN Industry Standards Source License 1.2", "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html").setAlternateNames("SISSL-1.2");
 	}
 
 	private KnownLicense addLicense(final String name, final String... knownUrls) {


### PR DESCRIPTION
This license is used e.g. by the DRMAA API and its SGE implementation,
from https://arc.liv.ac.uk/trac/SGE

Signed-off-by: Erwin De Ley <erwindl0@gmail.com>