### PR TITLE
Dependency declarations in osgi.bnd should have an upper bound.

### DIFF
--- a/releng/maven-plugins/ebr-maven-plugin/src/main/java/org/eclipse/ebr/maven/OsgiBndUtil.java
+++ b/releng/maven-plugins/ebr-maven-plugin/src/main/java/org/eclipse/ebr/maven/OsgiBndUtil.java
@@ -70,7 +70,7 @@ public class OsgiBndUtil extends BaseUtility {
 		declarations.append("package-version=${version;===;${Bundle-Version}}");
 		for (final Dependency dependency : dependencies) {
 			declarations.appendNewLine();
-			declarations.append(format("%s=${version;===;%s}", getVersionVariableName(dependency), dependency.getVersion()));
+			declarations.append(format("%s=${range;[===,+);%s}", getVersionVariableName(dependency), dependency.getVersion()));
 		}
 		return declarations.toString();
 	}


### PR DESCRIPTION
A dependency declaration with no upper bound can become a problem when
newer versions of the dependency are introduced and the unbounded
requirement becomes forgotten.

Assuming some users may not be familiar with the format to specify a
"range", having them present by default gives some boilerplate and may
prevent conflicts.

Thoughts on doing this ? Of course the Import-Package statements would need to be manually written either way, but at least ${foo-version} would have an upper limit.