### PR TITLE
Update maven-bundle-plugin to 4.2.0.

### DIFF
--- a/releng/maven-plugins/ebr-maven-plugin/pom.xml
+++ b/releng/maven-plugins/ebr-maven-plugin/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>maven-bundle-plugin</artifactId>
-      <version>4.1.0</version>
+      <version>4.2.0</version>
       <type>maven-plugin</type>
     </dependency>
     <dependency>

--- a/releng/maven-plugins/ebr-maven-plugin/src/main/java/org/eclipse/ebr/maven/BundleMojo.java
+++ b/releng/maven-plugins/ebr-maven-plugin/src/main/java/org/eclipse/ebr/maven/BundleMojo.java
@@ -355,7 +355,7 @@ public class BundleMojo extends ManifestPlugin {
 			if (!unpackDependencies) {
 				initializeBndInstruction(BUNDLE_CLASSPATH, getBundleClassPathHeaderPopulatedWithDependencyJars());
 			}
-			execute(project, buildDependencyGraph(project), bndInstructions, new Properties()); // BND also needs transitive dependencies
+			execute(bndInstructions, getClasspath(project)); // BND also needs transitive dependencies
 		} catch (final Exception e) {
 			throw new MojoExecutionException("Error generating Bundle manifest: " + e.getMessage(), e);
 		}


### PR DESCRIPTION
Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

I tried this out and can confirm it ignored the 'module-info' file when crafting the Required-Capability header.