### PR TITLE
Upgrade maven-bundle-plugin to 5.1.1 to make EBR compatible with JDK-15

### DIFF
--- a/releng/maven-plugins/ebr-maven-plugin/pom.xml
+++ b/releng/maven-plugins/ebr-maven-plugin/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>maven-bundle-plugin</artifactId>
-      <version>4.2.1</version>
+      <version>5.1.1</version>
       <type>maven-plugin</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
Per the issue here: https://github.com/bndtools/bnd/wiki/Changes-in-5.1.1#fixes-since-510
