### PR TITLE
Restore "Port to Tycho 2.0.0"

### DIFF
--- a/releng/maven-plugins/ebr-tycho-extras-plugin/src/main/java/org/eclipse/ebr/tycho/extras/plugin/AssembleBundleP2RepositoryMojo.java
+++ b/releng/maven-plugins/ebr-tycho-extras-plugin/src/main/java/org/eclipse/ebr/tycho/extras/plugin/AssembleBundleP2RepositoryMojo.java
@@ -319,8 +319,8 @@ public class AssembleBundleP2RepositoryMojo extends AbstractRepositoryMojo {
 		final TargetPlatformConfiguration configuration = configurationReader.getTargetPlatformConfiguration(session, project);
 		project.setContextValue(TychoConstants.CTX_TARGET_PLATFORM_CONFIGURATION, configuration);
 
-		final ExecutionEnvironmentConfiguration eeConfiguration = new ExecutionEnvironmentConfigurationImpl(logger, !configuration.isResolveWithEEConstraints());
-		dr.readExecutionEnvironmentConfiguration(project, eeConfiguration);
+		final ExecutionEnvironmentConfiguration eeConfiguration = new ExecutionEnvironmentConfigurationImpl(logger, !configuration.isResolveWithEEConstraints(), null, session);
+		dr.readExecutionEnvironmentConfiguration(project, session, eeConfiguration);
 		project.setContextValue(TychoConstants.CTX_EXECUTION_ENVIRONMENT_CONFIGURATION, eeConfiguration);
 
 		// we assume dependency resolution was done when generating p2 metadata

--- a/releng/maven-plugins/pom.xml
+++ b/releng/maven-plugins/pom.xml
@@ -67,7 +67,7 @@
     <minimum-maven-version>3.6.3</minimum-maven-version>
     <maven-plugin-plugin-version>3.6.0</maven-plugin-plugin-version>
     <takari-maven-plugin-testing-version>2.9.2</takari-maven-plugin-testing-version>
-    <tycho-version>1.7.0</tycho-version>
+    <tycho-version>2.0.0</tycho-version>
     <apache-httpclient-version>4.5.12</apache-httpclient-version>
   </properties>
 


### PR DESCRIPTION
Reverts eclipse/ebr#42, restoring eclipse/ebr#41

This should go in *after* we did a 1.3 release.