### PR TITLE
Revert "Upgrade maven-bundle-plugin to 5.1.1 to make EBR compatible w…

### DIFF
--- a/releng/maven-plugins/ebr-maven-plugin/pom.xml
+++ b/releng/maven-plugins/ebr-maven-plugin/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>maven-bundle-plugin</artifactId>
-      <version>5.1.1</version>
+      <version>4.2.1</version>
       <type>maven-plugin</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
…ith JDK-15-EA per the issue here: https://github.com/bndtools/bnd/wiki/Changes-in-5.1.1#fixes-since-510"

This reverts commit 7edf5abdba1deb27dbe1ec10e1040e3b684a280e.
It breaks generation of capabilities as described in upstream issue https://issues.apache.org/jira/browse/FELIX-6337
