### PR TITLE
Migrate maven plug-ins to Eclipse Orbit, bump version

### DIFF
--- a/releng/maven-plugins/CHANGELOG.md
+++ b/releng/maven-plugins/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to the Maven plug-ins will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 Semantic Versioning does not apply.
 
-## [Unreleased]
+## 2.0.0-SNAPSHOT (Unreleased)
+
+- Migrate EBR to the Eclipse Orbit project
+
+## 1.3.0 -> 1.4.0
+
+Details of changes missing
 
 ## 1.2.0 - 2020-06-24
 ### Changed

--- a/releng/maven-plugins/README.md
+++ b/releng/maven-plugins/README.md
@@ -1,11 +1,7 @@
 A set of Maven plugins that simplifies and automates working
 with Eclipse Bundle Recipies via Maven.
 
-wiki: [http://wiki.eclipse.org/EBR](http://wiki.eclipse.org/EBR)
-
-mailing list: [https://dev.eclipse.org/mailman/listinfo/ebr-dev](https://dev.eclipse.org/mailman/listinfo/ebr-dev)
-
-bugzilla: [https://bugs.eclipse.org](https://bugs.eclipse.org/bugs/buglist.cgi?list_id=6321580&classification=Eclipse%20Foundation&query_format=advanced&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&product=CBI)
+Part of the [Eclipse Orbit](https://projects.eclipse.org/projects/tools.orbit) project.
 
 Using the plugins
 =================

--- a/releng/maven-plugins/ebr-maven-plugin-its/pom.xml
+++ b/releng/maven-plugins/ebr-maven-plugin-its/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.eclipse.ebr</groupId>
     <artifactId>ebr-maven-plugins-parent</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Eclipse Bundle Recipe Maven Plugin Integration Tests</name>

--- a/releng/maven-plugins/ebr-maven-plugin/pom.xml
+++ b/releng/maven-plugins/ebr-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.eclipse.ebr</groupId>
     <artifactId>ebr-maven-plugins-parent</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Eclipse Bundle Recipe Maven Plugin</name>

--- a/releng/maven-plugins/ebr-maven-shared/pom.xml
+++ b/releng/maven-plugins/ebr-maven-shared/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.eclipse.ebr</groupId>
     <artifactId>ebr-maven-plugins-parent</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Eclipse Bundle Recipe Maven Shared Code</name>

--- a/releng/maven-plugins/ebr-tycho-extras-plugin/pom.xml
+++ b/releng/maven-plugins/ebr-tycho-extras-plugin/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>ebr-maven-plugins-parent</artifactId>
     <groupId>org.eclipse.ebr</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Eclipse Bundle Recipe Tycho Extras Plugin</name>

--- a/releng/maven-plugins/pom.xml
+++ b/releng/maven-plugins/pom.xml
@@ -8,13 +8,13 @@
 
   <groupId>org.eclipse.ebr</groupId>
   <artifactId>ebr-maven-plugins-parent</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Eclipse Bundle Recipe Maven Plugins</name>
-  <description>Eclipse Bundle Recipe Maven plugins for simplfying and automating working with Eclipse Bundle Recipies.
+  <description>Eclipse Bundle Recipe Maven plugins for simplfying and automating working with Eclipse Bundle Recipies. Part of Eclipse Orbit project.
   </description>
-  <url>http://www.eclipse.org/ebr</url>
+  <url>https://projects.eclipse.org/projects/tools.orbit</url>
 
   <licenses>
     <license>
@@ -30,8 +30,8 @@
   </organization>
 
   <issueManagement>
-    <system>Bugzilla</system>
-    <url>https://bugs.eclipse.org/bugs/buglist.cgi?product=EBR</url>
+    <system>GitHub Issues</system>
+    <url>https://github.com/eclipse/ebr/issues</url>
   </issueManagement>
 
   <scm>
@@ -46,6 +46,9 @@
     </developer>
     <developer>
       <name>Roland Grunberg</name>
+    </developer>
+    <developer>
+      <name>Jonah Graham</name>
     </developer>
   </developers>
 


### PR DESCRIPTION
To indicate more clearly that this is the version of the EBR bundles post moving to Eclipse Orbit, bump version and update references to be to Orbit.